### PR TITLE
Optional arguments to objective function

### DIFF
--- a/neighpy/search.py
+++ b/neighpy/search.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
-from typing import Any, Tuple, Protocol, Concatenate, ParamSpec, Callable
+from typing import Any, Tuple, Protocol
 from joblib import Parallel, delayed
 from tqdm import tqdm
 
@@ -11,10 +11,14 @@ class ObjectiveFunction(Protocol):
         # as long as its first argument is of type NDArray and returns a float
         # A type hint of Callable[[NDArray], float] would be too restrictive
         # A type checker will probably complain about this, but it's the best we can do for now
+        # From python 3.10, we can use ParamSpec to define a generic type hint for the objective
+        # function, and remove this protocol
+        #
+        # Example:
+        # P = ParamSpec("P")
+        # class NASearcher:
+        #     def __init__(self, objective: Callable[Concatenate[NDArray, P], float]):
         ...
-
-
-P = ParamSpec("P")
 
 
 class NASearcher:
@@ -32,7 +36,7 @@ class NASearcher:
 
     def __init__(
         self,
-        objective: Callable[Concatenate[NDArray, P], float],
+        objective: ObjectiveFunction,
         ns: int,
         nr: int,
         ni: int,

--- a/neighpy/search.py
+++ b/neighpy/search.py
@@ -6,6 +6,10 @@ from tqdm import tqdm
 
 
 class ObjectiveFunction(Protocol):
+    """
+    :meta private:
+    """
+
     def __call__(self, x: NDArray, *args: Any) -> float:
         # Any type hint because the objective function supplied by the user can have any signature
         # as long as its first argument is of type NDArray and returns a float
@@ -32,6 +36,7 @@ class NASearcher:
         n (int): The number of iterations.
         bounds (Tuple[Tuple[float, float], ...]): A tuple of tuples representing the bounds of the search space.
             Each inner tuple represents the lower and upper bounds for a specific dimension.
+        args (Tuple, optional): Additional arguments to pass to the objective function.
     """
 
     def __init__(

--- a/neighpy/search.py
+++ b/neighpy/search.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
-from typing import Any, Tuple, Protocol
+from typing import Any, Tuple, Protocol, Concatenate, ParamSpec, Callable
 from joblib import Parallel, delayed
 from tqdm import tqdm
 
@@ -12,6 +12,9 @@ class ObjectiveFunction(Protocol):
         # A type hint of Callable[[NDArray], float] would be too restrictive
         # A type checker will probably complain about this, but it's the best we can do for now
         ...
+
+
+P = ParamSpec("P")
 
 
 class NASearcher:
@@ -29,7 +32,7 @@ class NASearcher:
 
     def __init__(
         self,
-        objective: ObjectiveFunction,
+        objective: Callable[Concatenate[NDArray, P], float],
         ns: int,
         nr: int,
         ni: int,

--- a/neighpy/search.py
+++ b/neighpy/search.py
@@ -1,8 +1,17 @@
 import numpy as np
 from numpy.typing import NDArray
-from typing import Callable, Tuple
+from typing import Any, Tuple, Protocol
 from joblib import Parallel, delayed
 from tqdm import tqdm
+
+
+class ObjectiveFunction(Protocol):
+    def __call__(self, x: NDArray, *args: Any) -> float:
+        # Any type hint because the objective function supplied by the user can have any signature
+        # as long as its first argument is of type NDArray and returns a float
+        # A type hint of Callable[[NDArray], float] would be too restrictive
+        # A type checker will probably complain about this, but it's the best we can do for now
+        ...
 
 
 class NASearcher:
@@ -20,14 +29,16 @@ class NASearcher:
 
     def __init__(
         self,
-        objective: Callable[[NDArray], float],
+        objective: ObjectiveFunction,
         ns: int,
         nr: int,
         ni: int,
         n: int,
         bounds: Tuple[Tuple[float, float], ...],
+        args: Tuple = (),
     ) -> None:
-        self.objective = objective
+        self._objective = objective
+        self.objective_args = args
 
         self.ns = ns  # number of samples generated at each iteration
         self.nr = nr  # number of cells to resample
@@ -77,6 +88,9 @@ class NASearcher:
                 for k, cell in zip(inds, cells_to_resample)
             )
             self._update_ensemble(np.concatenate(new_samples))
+
+    def objective(self, x: NDArray) -> float:
+        return self._objective(x, *self.objective_args)
 
     def _initial_random_search(self) -> NDArray:
         return np.random.uniform(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -118,3 +118,16 @@ def test_run(NAS):
     assert np.all(NAS.samples >= NAS.lower)
     assert np.all(NAS.samples <= NAS.upper)
     assert NAS.np == NAS.nt
+
+
+def test_objective_args():
+    def objective(x: NDArray, a: int, b: float) -> float:
+        return (-np.sum(x) * a) / b
+
+    a = 2
+    b = 3.0
+    args = (a, b)
+    NAS = NASearcher(objective, 10, 5, 5, 20, ((-1.0, 1.0), (0.0, 10.0)), args=args)
+
+    x = np.array([1, 2, 3])
+    assert NAS.objective(x) == -4.0


### PR DESCRIPTION
Users can now pass optional arguments for the objective function to the `Searcher` class upon initialisation.

Closes #3 