### PR TITLE
Appraiser threshold

### DIFF
--- a/neighpy/appraise.py
+++ b/neighpy/appraise.py
@@ -65,13 +65,14 @@ class NAAppraiser:
         ss = np.random.SeedSequence(seed)
         self.rngs = [np.random.default_rng(s) for s in ss.spawn(self.j)]
 
-    def run(self, save: bool = True) -> None:
+    def run(self, save: bool = True, start_fraction: float = 0.5) -> None:
         """
         Perform the appraisal stage of the Neighbourhood Algorithm.
         Calculates a few basic MC integrals (mean, covariance and their errors).
 
         Args:
             save: bool - whether to save the new samples from the appraisal.  Set to :code:False to save memory, or if you only want a mean and covariance.
+            start_fraction: float - the fraction of the best cells to start the random walks from.  This is used to avoid walking in low probability regions.  Only used if :code:`n_walkers > 1`.
 
         Populates the following attributes:
 
@@ -84,7 +85,9 @@ class NAAppraiser:
         if self.j == 1:
             accumulator = self._run_serial(save)
         else:
-            accumulator = self._run_parallel(save)
+            if start_fraction < 0 or start_fraction > 1:
+                raise ValueError("start_fraction must be between 0 and 1")
+            accumulator = self._run_parallel(save, start_fraction)
 
         self.mean = accumulator.mean()
         self.sample_mean_error = accumulator.sample_mean_error()
@@ -100,14 +103,17 @@ class NAAppraiser:
             accumulator.accumulate(x)
         return accumulator
 
-    def _run_parallel(self, save: bool = True) -> MCIntegrals:
+    def _run_parallel(
+        self, save: bool = True, start_fraction: float = 0.5
+    ) -> MCIntegrals:
         n_jobs = min(self.j, cpu_count())
         with Parallel(n_jobs=n_jobs) as parallel:
             # select start points for the random walks
-            # these are taken from the best 50% of cells to avoid walking
+            # these are taken from the best start_fraction*100% of cells to avoid walking
             # in low probability regions
+            int_threshold = int(self.Ne * start_fraction)
             start_points = np.random.choice(
-                np.argpartition(self.log_ppd, -self.Ne // 2)[-self.Ne // 2 :],
+                np.argpartition(self.log_ppd, -int_threshold)[-int_threshold:],
                 self.j,
                 replace=False,
             )

--- a/neighpy/appraise.py
+++ b/neighpy/appraise.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import warnings
 from joblib import Parallel, delayed
 from tqdm import tqdm
+from os import cpu_count
 
 from ._mcintegrals import MCIntegrals
 from .search import NASearcher
@@ -100,7 +101,8 @@ class NAAppraiser:
         return accumulator
 
     def _run_parallel(self, save: bool = True) -> MCIntegrals:
-        with Parallel(n_jobs=self.j) as parallel:
+        n_jobs = min(self.j, cpu_count())
+        with Parallel(n_jobs=n_jobs) as parallel:
             # select start points for the random walks
             # these are taken from the best 50% of cells to avoid walking
             # in low probability regions

--- a/neighpy/search.py
+++ b/neighpy/search.py
@@ -3,6 +3,7 @@ from numpy.typing import NDArray
 from typing import Any, Tuple, Protocol, Union
 from joblib import Parallel, delayed
 from tqdm import tqdm
+from os import cpu_count
 
 
 class ObjectiveFunction(Protocol):
@@ -100,7 +101,8 @@ class NASearcher:
             self._current_best_ind = inds[0]
             cells_to_resample = self.samples[inds]
 
-            new_samples = Parallel(n_jobs=self.nr if parallel else 1)(
+            n_jobs = min(self.nr, cpu_count()) if parallel else 1
+            new_samples = Parallel(n_jobs=n_jobs)(
                 delayed(self._random_walk_in_voronoi)(cell, k, rng)
                 for k, cell, rng in zip(inds, cells_to_resample, self.rngs)
             )


### PR DESCRIPTION
Adds an option to the `NAAppraiser.run` method that lets the user set the threshold for the worst possible starting point.

When run with multiple walkers, by default the walkers' starting positions will be chosen from the best 50% of samples.  Now the user can choose to start from the best e.g. 40% by setting `start_fraction=0.4` 